### PR TITLE
Initialize repository

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,41 @@
+---
+name: Bug Report
+about: Help us diagnose and fix bugs in InfluxDB Cloud Provider.
+labels: bug
+---
+<!--
+Thank you for helping to improve InfluxDB Cloud Provider!
+
+Please be sure to search for open issues before raising a new one. We use issues
+for bug reports and feature requests. Please find us at https://slack.crossplane.io
+for questions, support, and discussion.
+-->
+
+### What happened?
+<!--
+Please let us know what behaviour you expected and how InfluxDB Cloud Provider
+diverged from that behaviour.
+-->
+
+
+### How can we reproduce it?
+<!--
+Help us to reproduce your bug as succinctly and precisely as possible. Artifacts
+such as example manifests or a script that triggers the issue are highly
+appreciated!
+-->
+
+### What environment did it happen in?
+Crossplane version: 
+Provider InfluxDB Cloud version:
+
+<!--
+Include at least the version or commit you were running. Consider
+also including your:
+
+* Cloud provider or hardware configuration
+* Kubernetes version (use `kubectl version`)
+* Kubernetes distribution (e.g. Tectonic, GKE, OpenShift)
+* OS (e.g. from /etc/os-release)
+* Kernel (e.g. `uname -a`)
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature Request
+about: Help us make InfluxDB Cloud Provider more useful
+labels: enhancement
+---
+<!--
+Thank you for helping to improve InfluxDB Cloud Provider!
+
+Please be sure to search for open issues before raising a new one. We use issues
+for bug reports and feature requests. Please find us at https://slack.crossplane.io
+for questions, support, and discussion.
+-->
+
+### What problem are you facing?
+<!--
+Please tell us a little about your use case - it's okay if it's hypothetical!
+Leading with this context helps frame the feature request so we can ensure we
+implement it sensibly.
+--->
+
+### How could InfluxDB Cloud Provider help solve your problem?
+<!--
+Let us know how you think InfluxDB Cloud Provider could help with your use case.
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,35 @@
+<!--
+Thank you for helping to improve Provider InfluxDB Cloud!
+
+Please read through https://git.io/fj2m9 if this is your first time opening a
+Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
+you need any help contributing.
+-->
+
+### Description of your changes
+
+<!--
+Briefly describe what this pull request does. Be sure to direct your reviewers'
+attention to anything that needs special consideration.
+
+We love pull requests that resolve an open Provider InfluxDB Cloud issue. If yours
+does, you can uncomment the below line to indicate which issue your PR fixes,
+for example "Fixes #500":
+
+-->
+Fixes #
+
+I have:
+
+- [ ] Read and followed Crossplane's [contribution process].
+- [ ] Run `make reviewable test` to ensure this PR is ready for review.
+
+### How has this code been tested
+
+<!--
+Before reviewers can be confident in the correctness of this pull request, it
+needs to tested and shown to be correct. Briefly describe the testing that has
+already been done or which is planned for this change.
+-->
+
+[contribution process]: https://git.io/fj2m9

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,38 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 90
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 7
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+exemptLabels:
+  - security
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Label to use when marking as stale
+staleLabel: wontfix
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: >
+  This issue has been automatically closed due to inactivity. Please re-open
+  if this still requires investigation.
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 30
+
+# Limit to only `issues` or `pulls`
+only: issues

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -1,0 +1,34 @@
+name: Backport
+
+on:
+  # NOTE(negz): This is a risky target, but we run this action only when and if
+  # a PR is closed, then filter down to specifically merged PRs. We also don't
+  # invoke any scripts, etc from within the repo. I believe the fact that we'll
+  # be able to review PRs before this runs makes this fairly safe.
+  # https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+  pull_request_target:
+    types: [closed]
+  # See also commands.yml for the /backport triggered variant of this workflow.
+
+jobs:
+  # NOTE(negz): I tested many backport GitHub actions before landing on this
+  # one. Many do not support merge commits, or do not support pull requests with
+  # more than one commit. This one does. It also handily links backport PRs with
+  # new PRs, and provides commentary and instructions when it can't backport.
+  # The main gotchas with this action are that it _only_ supports merge commits,
+  # and that PRs _must_ be labelled before they're merged to trigger a backport.
+  open-pr:
+    runs-on: ubuntu-18.04
+    if: github.event.pull_request.merged
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Open Backport PR
+        uses: zeebe-io/backport-action@v0.0.4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_workspace: ${{ github.workspace }}
+          version: v0.0.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,328 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - release-*
+  pull_request: {}
+  workflow_dispatch: {}
+
+env:
+  # Common versions
+  GO_VERSION: '1.16'
+  GOLANGCI_VERSION: 'v1.31'
+  DOCKER_BUILDX_VERSION: 'v0.4.2'
+
+  # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
+  # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
+  # credentials have been provided before trying to run steps that need them.
+  DOCKER_USR: ${{ secrets.DOCKER_USR }}
+  AWS_USR: ${{ secrets.AWS_USR }}
+
+jobs:
+  detect-noop:
+    runs-on: ubuntu-18.04
+    outputs:
+      noop: ${{ steps.noop.outputs.should_skip }}
+    steps:
+      - name: Detect No-op Changes
+        id: noop
+        uses: fkirc/skip-duplicate-actions@v2.0.0
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          paths_ignore: '["**.md", "**.png", "**.jpg"]'
+          do_not_skip: '["workflow_dispatch", "schedule", "push"]'
+
+
+  lint:
+    runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-lint-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-lint-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@v2
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      # Go version coming with golangci-lint-action may not be our desired
+      # go version. We deploy our desired go version and then skip go
+      # installation in golangci-lint-action in the next step as suggested
+      # in https://github.com/golangci/golangci-lint-action/issues/183
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      # We could run 'make lint' to ensure our desired Go version, but we
+      # prefer this action because it leaves 'annotations' (i.e. it comments
+      # on PRs to point out linter violations).
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: ${{ env.GOLANGCI_VERSION }}
+          skip-go-installation: true
+          args: --timeout 10m0s
+
+  check-diff:
+    runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-check-diff-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-check-diff-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@v2
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Check Diff
+        run: make check-diff
+
+  unit-tests:
+    runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-unit-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-unit-tests-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@v2
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Run Unit Tests
+        run: make -j2 test
+
+      - name: Publish Unit Test Coverage
+        uses: codecov/codecov-action@v1
+        with:
+          flags: unittests
+          file: _output/tests/linux_amd64/coverage.txt
+
+  e2e-tests:
+    runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+
+    steps:
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: ${{ env.DOCKER_BUILDX_VERSION }}
+          install: true
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-e2e-tests-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-e2e-tests-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@v2
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Build Helm Chart
+        run: make -j2 build
+        env:
+          # We're using docker buildx, which doesn't actually load the images it
+          # builds by default. Specifying --load does so.
+          BUILD_ARGS: "--load"
+
+      - name: Run E2E Tests
+        run: make e2e USE_HELM3=true
+
+  publish-artifacts:
+    runs-on: ubuntu-18.04
+    needs: detect-noop
+    if: needs.detect-noop.outputs.noop != 'true'
+
+    steps:
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@v1
+        with:
+          platforms: all
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@v1
+        with:
+          version: ${{ env.DOCKER_BUILDX_VERSION }}
+          install: true
+
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Find the Go Build Cache
+        id: go
+        run: echo "::set-output name=cache::$(go env GOCACHE)"
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.go.outputs.cache }}
+          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-publish-artifacts-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@v2
+        with:
+          path: .work/pkg
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Build Artifacts
+        run: make -j2 build.all
+        env:
+          # We're using docker buildx, which doesn't actually load the images it
+          # builds by default. Specifying --load does so.
+          BUILD_ARGS: "--load"
+      
+      - name: Publish Artifacts to GitHub
+        uses: actions/upload-artifact@v2
+        with:
+          name: output
+          path: _output/**
+      
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: env.DOCKER_USR != ''
+        with:
+          username: ${{ secrets.DOCKER_USR }}
+          password: ${{ secrets.DOCKER_PSW }}
+      
+      - name: Publish Artifacts to S3 and Docker Hub
+        run: make -j2 publish BRANCH_NAME=${GITHUB_REF##*/}
+        if: env.AWS_USR != '' && env.DOCKER_USR != ''
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+          GIT_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Promote Artifacts in S3 and Docker Hub
+        if: github.ref == 'refs/heads/main' && env.AWS_USR != '' && env.DOCKER_USR != ''
+        run: make -j2 promote
+        env:
+          BRANCH_NAME: main
+          CHANNEL: main
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+        

--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,0 +1,92 @@
+name: Comment Commands
+
+on: issue_comment
+
+jobs:
+  points:
+    runs-on: ubuntu-18.04
+    if: startsWith(github.event.comment.body, '/points')
+
+    steps:
+    - name: Extract Command
+      id: command
+      uses: xt0rted/slash-command-action@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        command: points
+        reaction: "true"
+        reaction-type: "eyes"
+        allow-edits: "false"
+        permission-level: write
+    - name: Handle Command
+      uses: actions/github-script@v4
+      env:
+        POINTS: ${{ steps.command.outputs.command-arguments }}
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          const points = process.env.POINTS
+
+          if (isNaN(parseInt(points))) {
+            console.log("Malformed command - expected '/points <int>'")
+            github.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: "confused"
+            })
+            return
+          }
+          const label = "points/" + points
+
+          // Delete our needs-points-label label.
+          try {
+            await github.issues.deleteLabel({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              name: ['needs-points-label']
+            })
+            console.log("Deleted 'needs-points-label' label.")
+          }
+          catch(e) {
+            console.log("Label 'needs-points-label' probably didn't exist.")
+          }
+
+          // Add our points label.
+          github.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: [label]
+          })
+          console.log("Added '" + label + "' label.")
+
+  # NOTE(negz): See also backport.yml, which is the variant that triggers on PR
+  # merge rather than on comment.
+  backport:
+    runs-on: ubuntu-18.04
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '/backport')
+    steps:
+    - name: Extract Command
+      id: command
+      uses: xt0rted/slash-command-action@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        command: backport
+        reaction: "true"
+        reaction-type: "eyes"
+        allow-edits: "false"
+        permission-level: write
+
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Open Backport PR
+      uses: zeebe-io/backport-action@v0.0.4
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        github_workspace: ${{ github.workspace }}
+        version: v0.0.4

--- a/.github/workflows/promote.yml
+++ b/.github/workflows/promote.yml
@@ -1,0 +1,49 @@
+name: Promote
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v0.1.0)'
+        required: true
+      channel:
+        description: 'Release channel'
+        required: true
+        default: 'alpha'
+
+env:
+  # Common users. We can't run a step 'if secrets.AWS_USR != ""' but we can run
+  # a step 'if env.AWS_USR' != ""', so we copy these to succinctly test whether
+  # credentials have been provided before trying to run steps that need them.
+  DOCKER_USR: ${{ secrets.DOCKER_USR }}
+  AWS_USR: ${{ secrets.AWS_USR }}
+
+jobs:
+  promote-artifacts:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Login to Docker
+        uses: docker/login-action@v1
+        if: env.DOCKER_USR != ''
+        with:
+          username: ${{ secrets.DOCKER_USR }}
+          password: ${{ secrets.DOCKER_PSW }}
+
+      - name: Promote Artifacts in S3 and Docker Hub
+        if: env.AWS_USR != '' && env.DOCKER_USR != ''
+        run: make -j2 promote BRANCH_NAME=${GITHUB_REF##*/}
+        env:
+          VERSION: ${{ github.event.inputs.version }}
+          CHANNEL: ${{ github.event.inputs.channel }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_USR }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_PSW }}
+        

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,26 @@
+name: Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Release version (e.g. v0.1.0)'
+        required: true
+      message:
+        description: 'Tag message'
+        required: true
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-18.04
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Create Tag
+        uses: negz/create-tag@v1
+        with:
+          version: ${{ github.event.inputs.version }}
+          message: ${{ github.event.inputs.message }}
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,11 @@
-/bin
+/.cache
+/.work
+/_output
+cover.out
 /vendor
 /.vendor-new
-.vscode
-.idea
 .DS_Store
+
+# ignore IDE folders
+.vscode/
+.idea/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "build"]
+	path = build
+	url = https://github.com/upbound/build

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@ run:
   deadline: 2m
 
   skip-files:
-  - "zz_generated\\..+\\.go$"
+  - "zz_\\..+\\.go$"
 
 output:
   # colored-line-number|line-number|json|tab|checkstyle|code-climate, default is "colored-line-number"
@@ -38,7 +38,7 @@ linters-settings:
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
-    local-prefixes: github.com/crossplane/provider-influxdb-cloud
+    local-prefixes: github.com/crossplane-contrib/provider-influxdb-cloud
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters-settings:
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
-    local-prefixes: github.com/crossplane-contrib/provider-influxdb-cloud
+    local-prefixes: github.com/crossplane-contrib/provider-influxdb
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters-settings:
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
-    local-prefixes: github.com/crossplane/provider-template
+    local-prefixes: github.com/crossplane/provider-influxdb-cloud
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ SHELL := /bin/bash
 
 # Options
 ORG_NAME=crossplane
-PROVIDER_NAME=provider-template
+PROVIDER_NAME=provider-influxdb-cloud
 
 build: generate test
 	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ./bin/$(PROVIDER_NAME)-controller cmd/provider/main.go

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 # ====================================================================================
 # Setup Project
 
-PROJECT_NAME := provider-influxdb-cloud
+PROJECT_NAME := provider-influxdb
 PROJECT_REPO := github.com/crossplane-contrib/$(PROJECT_NAME)
 
 PLATFORMS ?= linux_amd64 linux_arm64

--- a/Makefile
+++ b/Makefile
@@ -1,42 +1,90 @@
-# Set the shell to bash always
-SHELL := /bin/bash
+# ====================================================================================
+# Setup Project
 
-# Options
-ORG_NAME=crossplane
-PROVIDER_NAME=provider-influxdb-cloud
+PROJECT_NAME := provider-influxdb-cloud
+PROJECT_REPO := github.com/crossplane-contrib/$(PROJECT_NAME)
 
-build: generate test
-	@CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o ./bin/$(PROVIDER_NAME)-controller cmd/provider/main.go
+PLATFORMS ?= linux_amd64 linux_arm64
 
-image: generate test
-	docker build . -t $(ORG_NAME)/$(PROVIDER_NAME):latest -f cluster/Dockerfile
+# -include will silently skip missing files, which allows us
+# to load those files with a target in the Makefile. If only
+# "include" was used, the make command would fail and refuse
+# to run a target until the include commands succeeded.
+-include build/makelib/common.mk
 
-image-push:
-	docker push $(ORG_NAME)/$(PROVIDER_NAME):latest
+# ====================================================================================
+# Setup Output
 
-run: generate
-	kubectl apply -f package/crds/ -R
-	go run cmd/provider/main.go -d
+-include build/makelib/output.mk
 
-all: image image-push
+# ====================================================================================
+# Setup Go
 
-generate:
-	go generate ./...
-	@find package/crds -name *.yaml -exec sed -i.sed -e '1,2d' {} \;
-	@find package/crds -name *.yaml.sed -delete
+# Set a sane default so that the nprocs calculation below is less noisy on the initial
+# loading of this file
+NPROCS ?= 1
 
-lint:
-	$(LINT) run
+# each of our test suites starts a kube-apiserver and running many test suites in
+# parallel can lead to high CPU utilization. by default we reduce the parallelism
+# to half the number of CPU cores.
+GO_TEST_PARALLEL := $(shell echo $$(( $(NPROCS) / 2 )))
 
-tidy:
-	go mod tidy
+GO_STATIC_PACKAGES = $(GO_PROJECT)/cmd/provider
+GO_LDFLAGS += -X $(GO_PROJECT)/internal/version.Version=$(VERSION)
+GO_SUBDIRS += cmd internal apis
+GO111MODULE = on
+-include build/makelib/golang.mk
 
-test:
-	go test -v ./...
+# ====================================================================================
+# Setup Kubernetes tools
 
-# Tools
+-include build/makelib/k8s_tools.mk
 
-KIND=$(shell which kind)
-LINT=$(shell which golangci-lint)
+# ====================================================================================
+# Setup Images
 
-.PHONY: generate tidy lint clean build image all run
+DOCKER_REGISTRY := crossplane
+IMAGES = provider-jet-gcp provider-jet-gcp-controller
+-include build/makelib/image.mk
+
+# ====================================================================================
+# Targets
+
+# run `make help` to see the targets and options
+
+# We want submodules to be set up the first time `make` is run.
+# We manage the build/ folder and its Makefiles as a submodule.
+# The first time `make` is run, the includes of build/*.mk files will
+# all fail, and this target will be run. The next time, the default as defined
+# by the includes will be run instead.
+fallthrough: submodules
+	@echo Initial setup complete. Running make again . . .
+	@make
+
+# Generate a coverage report for cobertura applying exclusions on
+# - generated file
+cobertura:
+	@cat $(GO_TEST_OUTPUT)/coverage.txt | \
+		grep -v zz_ | \
+		$(GOCOVER_COBERTURA) > $(GO_TEST_OUTPUT)/cobertura-coverage.xml
+
+crds.clean:
+	@$(INFO) cleaning generated CRDs
+	@find package/crds -name '*.yaml' -exec sed -i.sed -e '1,2d' {} \; || $(FAIL)
+	@find package/crds -name '*.yaml.sed' -delete || $(FAIL)
+	@$(OK) cleaned generated CRDs
+
+# Update the submodules, such as the common build scripts.
+submodules:
+	@git submodule sync
+	@git submodule update --init --recursive
+
+# This is for running out-of-cluster locally, and is for convenience. Running
+# this make target will print out the command which was used. For more control,
+# try running the binary directly with different arguments.
+run: go.build
+	@$(INFO) Running Crossplane locally out-of-cluster . . .
+	@# To see other arguments that can be provided, run the command with --help instead
+	$(GO_OUT_DIR)/provider --debug
+
+.PHONY: cobertura submodules fallthrough run crds.clean

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Crossplane Provider for InfluxDB Cloud
+# Crossplane Provider for InfluxDB
 
 ## Overview
 
-This `provider-influxdb-cloud` repository is the Crossplane infrastructure provider for
-[InfluxDB Cloud](https://www.influxdata.com/products/influxdb-cloud/). The
-provider that is built from the source code in this repository can be installed
-into a Crossplane control plane and adds the following new functionality:
+This `provider-influxdb` repository is the Crossplane infrastructure provider for
+[InfluxDB](https://www.influxdata.com). The provider that is built from the
+source code in this repository can be installed into a Crossplane control plane
+and adds the following new functionality:
 
 * Custom Resource Definitions (CRDs) that model InfluxDB Cloud infrastructure and 
   services.
@@ -19,26 +19,15 @@ our [Documentation](https://crossplane.io/docs/latest).
 
 ## Contributing
 
-provider-influxdb-cloud is a community driven project and we welcome contributions. See the
-Crossplane
+provider-influxdb is a community driven project and we welcome contributions. 
+See the Crossplane
 [Contributing](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
 guidelines to get started.
-
-### Adding New Resource
-
-We use AWS Go code generation pipeline to generate new controllers. See [Code Generation Guide](CODE_GENERATION.md)
-to add a new resource.
-
-## Releases
-
-AWS Provider is released every 4 weeks and we issue patch releases as necessary.
-For example, `v0.20.0` is released on October 19, 2021. The next minor
-release `v0.21.0` will be cut on November 16, 2021, and so on.
 
 ## Report a Bug
 
 For filing bugs, suggesting improvements, or requesting new features, please
-open an [issue](https://github.com/crossplane-contrib/provider-influxdb-cloud/issues).
+open an [issue](https://github.com/crossplane-contrib/provider-influxdb/issues).
 
 ## Contact
 
@@ -52,23 +41,23 @@ Please use the following to reach members of the community:
 
 ## Roadmap
 
-provider-influxdb-cloud goals and milestones are currently tracked in the Crossplane
+provider-influxdb goals and milestones are currently tracked in the Crossplane
 repository. More information can be found in
 [ROADMAP.md](https://github.com/crossplane/crossplane/blob/master/ROADMAP.md).
 
 ## Governance and Owners
 
-provider-influxdb-cloud is run according to the same
+provider-influxdb is run according to the same
 [Governance](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md)
 and [Ownership](https://github.com/crossplane/crossplane/blob/master/OWNERS.md)
 structure as the core Crossplane project.
 
 ## Code of Conduct
 
-provider-influxdb-cloud adheres to the same [Code of
+provider-influxdb adheres to the same [Code of
 Conduct](https://github.com/crossplane/crossplane/blob/master/CODE_OF_CONDUCT.md)
 as the core Crossplane project.
 
 ## Licensing
 
-provider-influxdb-cloud is under the Apache 2.0 license.
+provider-influxdb is under the Apache 2.0 license.

--- a/README.md
+++ b/README.md
@@ -1,42 +1,74 @@
-# provider-template
+# Crossplane Provider for InfluxDB Cloud
 
-`provider-template` is a minimal [Crossplane](https://crossplane.io/) Provider
-that is meant to be used as a template for implementing new Providers. It comes
-with the following features that are meant to be refactored:
+## Overview
 
-- A `ProviderConfig` type that only points to a credentials `Secret`.
-- A `MyType` resource type that serves as an example managed resource.
-- A managed resource controller that reconciles `MyType` objects and simply
-  prints their configuration in its `Observe` method.
+This `provider-influxdb-cloud` repository is the Crossplane infrastructure provider for
+[InfluxDB Cloud](https://www.influxdata.com/products/influxdb-cloud/). The
+provider that is built from the source code in this repository can be installed
+into a Crossplane control plane and adds the following new functionality:
 
-## Developing
+* Custom Resource Definitions (CRDs) that model InfluxDB Cloud infrastructure and 
+  services.
+* Controllers to provision these resources in InfluxDB Cloud based on the users desired
+  state captured in CRDs they create
 
-Run against a Kubernetes cluster:
+## Getting Started and Documentation
 
-```console
-make run
-```
+For getting started guides, installation, deployment, and administration, see
+our [Documentation](https://crossplane.io/docs/latest).
 
-Build, push, and install:
+## Contributing
 
-```console
-make all
-```
+provider-influxdb-cloud is a community driven project and we welcome contributions. See the
+Crossplane
+[Contributing](https://github.com/crossplane/crossplane/blob/master/CONTRIBUTING.md)
+guidelines to get started.
 
-Build image:
+### Adding New Resource
 
-```console
-make image
-```
+We use AWS Go code generation pipeline to generate new controllers. See [Code Generation Guide](CODE_GENERATION.md)
+to add a new resource.
 
-Push image:
+## Releases
 
-```console
-make push
-```
+AWS Provider is released every 4 weeks and we issue patch releases as necessary.
+For example, `v0.20.0` is released on October 19, 2021. The next minor
+release `v0.21.0` will be cut on November 16, 2021, and so on.
 
-Build binary:
+## Report a Bug
 
-```console
-make build
-```
+For filing bugs, suggesting improvements, or requesting new features, please
+open an [issue](https://github.com/crossplane-contrib/provider-influxdb-cloud/issues).
+
+## Contact
+
+Please use the following to reach members of the community:
+
+* Slack: Join our [slack channel](https://slack.crossplane.io)
+* Forums:
+  [crossplane-dev](https://groups.google.com/forum/#!forum/crossplane-dev)
+* Twitter: [@crossplane_io](https://twitter.com/crossplane_io)
+* Email: [info@crossplane.io](mailto:info@crossplane.io)
+
+## Roadmap
+
+provider-influxdb-cloud goals and milestones are currently tracked in the Crossplane
+repository. More information can be found in
+[ROADMAP.md](https://github.com/crossplane/crossplane/blob/master/ROADMAP.md).
+
+## Governance and Owners
+
+provider-influxdb-cloud is run according to the same
+[Governance](https://github.com/crossplane/crossplane/blob/master/GOVERNANCE.md)
+and [Ownership](https://github.com/crossplane/crossplane/blob/master/OWNERS.md)
+structure as the core Crossplane project.
+
+## Code of Conduct
+
+provider-influxdb-cloud adheres to the same [Code of
+Conduct](https://github.com/crossplane/crossplane/blob/master/CODE_OF_CONDUCT.md)
+as the core Crossplane project.
+
+## Licensing
+
+provider-influxdb-cloud is under the Apache 2.0 license.

--- a/apis/sample/v1alpha1/groupversion_info.go
+++ b/apis/sample/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the v1alpha1 group Sample resources of the Template provider.
 // +kubebuilder:object:generate=true
-// +groupName=sample.template.crossplane.io
+// +groupName=sample.influxdbcloud.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -27,7 +27,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "sample.template.crossplane.io"
+	Group   = "sample.influxdbcloud.crossplane.io"
 	Version = "v1alpha1"
 )
 

--- a/apis/sample/v1alpha1/groupversion_info.go
+++ b/apis/sample/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the v1alpha1 group Sample resources of the Template provider.
 // +kubebuilder:object:generate=true
-// +groupName=sample.influxdbcloud.crossplane.io
+// +groupName=sample.influxdb.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -27,7 +27,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "sample.influxdbcloud.crossplane.io"
+	Group   = "sample.influxdb.crossplane.io"
 	Version = "v1alpha1"
 )
 

--- a/apis/sample/v1alpha1/mytype_types.go
+++ b/apis/sample/v1alpha1/mytype_types.go
@@ -54,7 +54,7 @@ type MyTypeStatus struct {
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.atProvider.state"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,template}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,influxdbcloud}
 type MyType struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/sample/v1alpha1/mytype_types.go
+++ b/apis/sample/v1alpha1/mytype_types.go
@@ -54,7 +54,7 @@ type MyTypeStatus struct {
 // +kubebuilder:printcolumn:name="STATUS",type="string",JSONPath=".status.bindingPhase"
 // +kubebuilder:printcolumn:name="STATE",type="string",JSONPath=".status.atProvider.state"
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,influxdbcloud}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,managed,influxdb}
 type MyType struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/template.go
+++ b/apis/template.go
@@ -20,14 +20,14 @@ package apis
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 
-	samplev1alpha1 "github.com/crossplane/provider-template/apis/sample/v1alpha1"
-	templatev1alpha1 "github.com/crossplane/provider-template/apis/v1alpha1"
+	samplev1alpha1 "github.com/crossplane/provider-influxdb-cloud/apis/sample/v1alpha1"
+	influxdbv1alpha1 "github.com/crossplane/provider-influxdb-cloud/apis/v1alpha1"
 )
 
 func init() {
 	// Register the types with the Scheme so the components can map objects to GroupVersionKinds and back
 	AddToSchemes = append(AddToSchemes,
-		templatev1alpha1.SchemeBuilder.AddToScheme,
+		influxdbv1alpha1.SchemeBuilder.AddToScheme,
 		samplev1alpha1.SchemeBuilder.AddToScheme,
 	)
 }

--- a/apis/template.go
+++ b/apis/template.go
@@ -20,8 +20,8 @@ package apis
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 
-	samplev1alpha1 "github.com/crossplane-contrib/provider-influxdb-cloud/apis/sample/v1alpha1"
-	influxdbv1alpha1 "github.com/crossplane-contrib/provider-influxdb-cloud/apis/v1alpha1"
+	samplev1alpha1 "github.com/crossplane-contrib/provider-influxdb/apis/sample/v1alpha1"
+	influxdbv1alpha1 "github.com/crossplane-contrib/provider-influxdb/apis/v1alpha1"
 )
 
 func init() {

--- a/apis/template.go
+++ b/apis/template.go
@@ -20,8 +20,8 @@ package apis
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 
-	samplev1alpha1 "github.com/crossplane/provider-influxdb-cloud/apis/sample/v1alpha1"
-	influxdbv1alpha1 "github.com/crossplane/provider-influxdb-cloud/apis/v1alpha1"
+	samplev1alpha1 "github.com/crossplane-contrib/provider-influxdb-cloud/apis/sample/v1alpha1"
+	influxdbv1alpha1 "github.com/crossplane-contrib/provider-influxdb-cloud/apis/v1alpha1"
 )
 
 func init() {

--- a/apis/v1alpha1/groupversion_info.go
+++ b/apis/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the core resources of the Template provider.
 // +kubebuilder:object:generate=true
-// +groupName=template.crossplane.io
+// +groupName=influxdbcloud.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -27,7 +27,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "template.crossplane.io"
+	Group   = "influxdbcloud.crossplane.io"
 	Version = "v1alpha1"
 )
 

--- a/apis/v1alpha1/groupversion_info.go
+++ b/apis/v1alpha1/groupversion_info.go
@@ -16,7 +16,7 @@ limitations under the License.
 
 // Package v1alpha1 contains the core resources of the Template provider.
 // +kubebuilder:object:generate=true
-// +groupName=influxdbcloud.crossplane.io
+// +groupName=influxdb.crossplane.io
 // +versionName=v1alpha1
 package v1alpha1
 
@@ -27,7 +27,7 @@ import (
 
 // Package type metadata.
 const (
-	Group   = "influxdbcloud.crossplane.io"
+	Group   = "influxdb.crossplane.io"
 	Version = "v1alpha1"
 )
 

--- a/apis/v1alpha1/providerconfigusage_types.go
+++ b/apis/v1alpha1/providerconfigusage_types.go
@@ -32,7 +32,7 @@ import (
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,influxdbcloud}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,influxdb}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha1/providerconfigusage_types.go
+++ b/apis/v1alpha1/providerconfigusage_types.go
@@ -32,7 +32,7 @@ import (
 // +kubebuilder:printcolumn:name="CONFIG-NAME",type="string",JSONPath=".providerConfigRef.name"
 // +kubebuilder:printcolumn:name="RESOURCE-KIND",type="string",JSONPath=".resourceRef.kind"
 // +kubebuilder:printcolumn:name="RESOURCE-NAME",type="string",JSONPath=".resourceRef.name"
-// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,template}
+// +kubebuilder:resource:scope=Cluster,categories={crossplane,provider,influxdbcloud}
 type ProviderConfigUsage struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -27,8 +27,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 
-	"github.com/crossplane/provider-template/apis"
-	"github.com/crossplane/provider-template/internal/controller"
+	"github.com/crossplane/provider-influxdb-cloud/apis"
+	"github.com/crossplane/provider-influxdb-cloud/internal/controller"
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	zl := zap.New(zap.UseDevMode(*debug))
-	log := logging.NewLogrLogger(zl.WithName("provider-template"))
+	log := logging.NewLogrLogger(zl.WithName("provider-influxdb-cloud"))
 	if *debug {
 		// The controller-runtime runs with a no-op logger by default. It is
 		// *very* verbose even at info level, so we only provide it a real
@@ -56,7 +56,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:   *leaderElection,
-		LeaderElectionID: "crossplane-leader-election-provider-template",
+		LeaderElectionID: "crossplane-leader-election-provider-influxdb-cloud",
 		SyncPeriod:       syncPeriod,
 	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -27,8 +27,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 
-	"github.com/crossplane/provider-influxdb-cloud/apis"
-	"github.com/crossplane/provider-influxdb-cloud/internal/controller"
+	"github.com/crossplane-contrib/provider-influxdb-cloud/apis"
+	"github.com/crossplane-contrib/provider-influxdb-cloud/internal/controller"
 )
 
 func main() {

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -27,8 +27,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 
-	"github.com/crossplane-contrib/provider-influxdb-cloud/apis"
-	"github.com/crossplane-contrib/provider-influxdb-cloud/internal/controller"
+	"github.com/crossplane-contrib/provider-influxdb/apis"
+	"github.com/crossplane-contrib/provider-influxdb/internal/controller"
 )
 
 func main() {
@@ -41,7 +41,7 @@ func main() {
 	kingpin.MustParse(app.Parse(os.Args[1:]))
 
 	zl := zap.New(zap.UseDevMode(*debug))
-	log := logging.NewLogrLogger(zl.WithName("provider-influxdb-cloud"))
+	log := logging.NewLogrLogger(zl.WithName("provider-influxdb"))
 	if *debug {
 		// The controller-runtime runs with a no-op logger by default. It is
 		// *very* verbose even at info level, so we only provide it a real
@@ -56,7 +56,7 @@ func main() {
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		LeaderElection:   *leaderElection,
-		LeaderElectionID: "crossplane-leader-election-provider-influxdb-cloud",
+		LeaderElectionID: "crossplane-leader-election-provider-influxdb",
 		SyncPeriod:       syncPeriod,
 	})
 	kingpin.FatalIfError(err, "Cannot create controller manager")

--- a/examples/provider/config.yaml
+++ b/examples/provider/config.yaml
@@ -7,7 +7,7 @@ type: Opaque
 data:
   # credentials: BASE64ENCODED_PROVIDER_CREDS
 ---
-apiVersion: influxdbcloud.crossplane.io/v1alpha1
+apiVersion: influxdb.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: example

--- a/examples/provider/config.yaml
+++ b/examples/provider/config.yaml
@@ -7,7 +7,7 @@ type: Opaque
 data:
   # credentials: BASE64ENCODED_PROVIDER_CREDS
 ---
-apiVersion: template.crossplane.io/v1alpha1
+apiVersion: influxdbcloud.crossplane.io/v1alpha1
 kind: ProviderConfig
 metadata:
   name: example

--- a/examples/sample/mytype.yaml
+++ b/examples/sample/mytype.yaml
@@ -1,4 +1,4 @@
-apiVersion: sample.influxdbcloud.crossplane.io/v1alpha1
+apiVersion: sample.influxdb.crossplane.io/v1alpha1
 kind: MyType
 metadata:
   name: example

--- a/examples/sample/mytype.yaml
+++ b/examples/sample/mytype.yaml
@@ -1,4 +1,4 @@
-apiVersion: sample.template.crossplane.io/v1alpha1
+apiVersion: sample.influxdbcloud.crossplane.io/v1alpha1
 kind: MyType
 metadata:
   name: example

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
-module github.com/crossplane-contrib/provider-influxdb-cloud
+module github.com/crossplane-contrib/provider-influxdb
 
 go 1.16
 
 require (
-	github.com/crossplane/crossplane-runtime v0.15.0
+	github.com/crossplane/crossplane-runtime v0.15.1
 	github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527
 	github.com/google/go-cmp v0.5.6
 	github.com/pkg/errors v0.9.1

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/crossplane/provider-template
+module github.com/crossplane/provider-influxdb-cloud
 
 go 1.16
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/crossplane/provider-influxdb-cloud
+module github.com/crossplane-contrib/provider-influxdb-cloud
 
 go 1.16
 

--- a/go.sum
+++ b/go.sum
@@ -123,8 +123,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
-github.com/crossplane/crossplane-runtime v0.15.0 h1:05a9ypKyt2BDdGycrx2iOhLImw+1SsfWR6zO2FO5nDM=
-github.com/crossplane/crossplane-runtime v0.15.0/go.mod h1:XvktCTRFTkdP2jR2PecrvhsxzSO8XT3jHxTOk/k+NL8=
+github.com/crossplane/crossplane-runtime v0.15.1 h1:4l3iTMyrQRkt9U0P1oJ6M71JMFGcIq95agFu7OPrwRE=
+github.com/crossplane/crossplane-runtime v0.15.1/go.mod h1:XvktCTRFTkdP2jR2PecrvhsxzSO8XT3jHxTOk/k+NL8=
 github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527 h1:9M6hMLKqjxtL9d9nwfcaAt59Ey0CPfSXQ3iIdYRUNaE=
 github.com/crossplane/crossplane-tools v0.0.0-20210320162312-1baca298c527/go.mod h1:C735A9X0x0lR8iGVOOxb49Mt70Ua4EM2b7PGaRPBLd4=
 github.com/dave/jennifer v1.3.0 h1:p3tl41zjjCZTNBytMwrUuiAnherNUZktlhPTKoF/sEk=

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -28,7 +28,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/providerconfig"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/crossplane-contrib/provider-influxdb-cloud/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-influxdb/apis/v1alpha1"
 )
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -28,7 +28,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/providerconfig"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/crossplane/provider-influxdb-cloud/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-influxdb-cloud/apis/v1alpha1"
 )
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -28,7 +28,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/providerconfig"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/crossplane/provider-template/apis/v1alpha1"
+	"github.com/crossplane/provider-influxdb-cloud/apis/v1alpha1"
 )
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for

--- a/internal/controller/mytype/mytype.go
+++ b/internal/controller/mytype/mytype.go
@@ -33,8 +33,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/crossplane/provider-template/apis/sample/v1alpha1"
-	apisv1alpha1 "github.com/crossplane/provider-template/apis/v1alpha1"
+	"github.com/crossplane/provider-influxdb-cloud/apis/sample/v1alpha1"
+	apisv1alpha1 "github.com/crossplane/provider-influxdb-cloud/apis/v1alpha1"
 )
 
 const (

--- a/internal/controller/mytype/mytype.go
+++ b/internal/controller/mytype/mytype.go
@@ -33,8 +33,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/crossplane/provider-influxdb-cloud/apis/sample/v1alpha1"
-	apisv1alpha1 "github.com/crossplane/provider-influxdb-cloud/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-influxdb-cloud/apis/sample/v1alpha1"
+	apisv1alpha1 "github.com/crossplane-contrib/provider-influxdb-cloud/apis/v1alpha1"
 )
 
 const (

--- a/internal/controller/mytype/mytype.go
+++ b/internal/controller/mytype/mytype.go
@@ -33,8 +33,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/crossplane-contrib/provider-influxdb-cloud/apis/sample/v1alpha1"
-	apisv1alpha1 "github.com/crossplane-contrib/provider-influxdb-cloud/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-influxdb/apis/sample/v1alpha1"
+	apisv1alpha1 "github.com/crossplane-contrib/provider-influxdb/apis/v1alpha1"
 )
 
 const (

--- a/internal/controller/template.go
+++ b/internal/controller/template.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
-	"github.com/crossplane-contrib/provider-influxdb-cloud/internal/controller/config"
-	"github.com/crossplane-contrib/provider-influxdb-cloud/internal/controller/mytype"
+	"github.com/crossplane-contrib/provider-influxdb/internal/controller/config"
+	"github.com/crossplane-contrib/provider-influxdb/internal/controller/mytype"
 )
 
 // Setup creates all Template controllers with the supplied logger and adds them to

--- a/internal/controller/template.go
+++ b/internal/controller/template.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
-	"github.com/crossplane/provider-template/internal/controller/config"
-	"github.com/crossplane/provider-template/internal/controller/mytype"
+	"github.com/crossplane/provider-influxdb-cloud/internal/controller/config"
+	"github.com/crossplane/provider-influxdb-cloud/internal/controller/mytype"
 )
 
 // Setup creates all Template controllers with the supplied logger and adds them to

--- a/internal/controller/template.go
+++ b/internal/controller/template.go
@@ -22,8 +22,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
-	"github.com/crossplane/provider-influxdb-cloud/internal/controller/config"
-	"github.com/crossplane/provider-influxdb-cloud/internal/controller/mytype"
+	"github.com/crossplane-contrib/provider-influxdb-cloud/internal/controller/config"
+	"github.com/crossplane-contrib/provider-influxdb-cloud/internal/controller/mytype"
 )
 
 // Setup creates all Template controllers with the supplied logger and adds them to

--- a/package/crds/influxdb.crossplane.io_providerconfigs.yaml
+++ b/package/crds/influxdb.crossplane.io_providerconfigs.yaml
@@ -6,9 +6,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
-  name: providerconfigs.influxdbcloud.crossplane.io
+  name: providerconfigs.influxdb.crossplane.io
 spec:
-  group: influxdbcloud.crossplane.io
+  group: influxdb.crossplane.io
   names:
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/package/crds/influxdb.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/influxdb.crossplane.io_providerconfigusages.yaml
@@ -6,14 +6,14 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
-  name: providerconfigusages.influxdbcloud.crossplane.io
+  name: providerconfigusages.influxdb.crossplane.io
 spec:
-  group: influxdbcloud.crossplane.io
+  group: influxdb.crossplane.io
   names:
     categories:
     - crossplane
     - provider
-    - influxdbcloud
+    - influxdb
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList
     plural: providerconfigusages

--- a/package/crds/influxdbcloud.crossplane.io_providerconfigs.yaml
+++ b/package/crds/influxdbcloud.crossplane.io_providerconfigs.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/influxdbcloud.crossplane.io_providerconfigs.yaml
+++ b/package/crds/influxdbcloud.crossplane.io_providerconfigs.yaml
@@ -4,9 +4,9 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
-  name: providerconfigs.template.crossplane.io
+  name: providerconfigs.influxdbcloud.crossplane.io
 spec:
-  group: template.crossplane.io
+  group: influxdbcloud.crossplane.io
   names:
     kind: ProviderConfig
     listKind: ProviderConfigList

--- a/package/crds/influxdbcloud.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/influxdbcloud.crossplane.io_providerconfigusages.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/influxdbcloud.crossplane.io_providerconfigusages.yaml
+++ b/package/crds/influxdbcloud.crossplane.io_providerconfigusages.yaml
@@ -4,14 +4,14 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
-  name: providerconfigusages.template.crossplane.io
+  name: providerconfigusages.influxdbcloud.crossplane.io
 spec:
-  group: template.crossplane.io
+  group: influxdbcloud.crossplane.io
   names:
     categories:
     - crossplane
     - provider
-    - template
+    - influxdbcloud
     kind: ProviderConfigUsage
     listKind: ProviderConfigUsageList
     plural: providerconfigusages

--- a/package/crds/sample.influxdb.crossplane.io_mytypes.yaml
+++ b/package/crds/sample.influxdb.crossplane.io_mytypes.yaml
@@ -6,14 +6,14 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
-  name: mytypes.sample.influxdbcloud.crossplane.io
+  name: mytypes.sample.influxdb.crossplane.io
 spec:
-  group: sample.influxdbcloud.crossplane.io
+  group: sample.influxdb.crossplane.io
   names:
     categories:
     - crossplane
     - managed
-    - influxdbcloud
+    - influxdb
     kind: MyType
     listKind: MyTypeList
     plural: mytypes

--- a/package/crds/sample.influxdbcloud.crossplane.io_mytypes.yaml
+++ b/package/crds/sample.influxdbcloud.crossplane.io_mytypes.yaml
@@ -1,3 +1,5 @@
+
+---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:

--- a/package/crds/sample.influxdbcloud.crossplane.io_mytypes.yaml
+++ b/package/crds/sample.influxdbcloud.crossplane.io_mytypes.yaml
@@ -4,14 +4,14 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.6.2
   creationTimestamp: null
-  name: mytypes.sample.template.crossplane.io
+  name: mytypes.sample.influxdbcloud.crossplane.io
 spec:
-  group: sample.template.crossplane.io
+  group: sample.influxdbcloud.crossplane.io
   names:
     categories:
     - crossplane
     - managed
-    - template
+    - influxdbcloud
     kind: MyType
     listKind: MyTypeList
     plural: mytypes


### PR DESCRIPTION
Usual ritual.

One thing I need to do some extra work is whether it should be `provider-influxdb-cloud` or just `provider-influxdb` because it seems like InfluxDB Cloud provides the same API as OSS. For example, you can [create organizations](https://docs.influxdata.com/influxdb/cloud/reference/cli/influx/org/create/#works-with-influxdb-oss-2x) in both but cloud requires a new sign-up whereas you can just call the API and there is only a [single Go](https://docs.influxdata.com/influxdb/cloud/api-guide/client-libraries/go/) client targeting both.