### PR TITLE
Fix not-found error detection

### DIFF
--- a/internal/controller/bucket/controller_test.go
+++ b/internal/controller/bucket/controller_test.go
@@ -78,7 +78,7 @@ func TestObserve(t *testing.T) {
 				mg: &v1alpha1.Bucket{},
 				api: &clients.MockBucketsAPI{
 					FindBucketByNameFn: func(_ context.Context, name string) (*domain.Bucket, error) {
-						return nil, fmt.Errorf("bucket '%s' not found", name)
+						return nil, fmt.Errorf(`bucket "%s" not found`, name)
 					},
 				},
 			},

--- a/internal/controller/bucket/conversions.go
+++ b/internal/controller/bucket/conversions.go
@@ -158,6 +158,6 @@ func IsUpToDate(params v1alpha1.BucketParameters, obs *domain.Bucket) bool {
 // of kind NotFound.
 func IsNotFoundFn(name string) resource.ErrorIs {
 	return func(err error) bool {
-		return strings.Contains(err.Error(), fmt.Sprintf("bucket '%s' not found", name))
+		return strings.Contains(err.Error(), fmt.Sprintf(`bucket "%s" not found`, name))
 	}
 }


### PR DESCRIPTION
Signed-off-by: Alper Rifat Ulucinar <ulucinar@users.noreply.github.com>

<!--
Thank you for helping to improve Provider InfluxDB Cloud!

Please read through https://git.io/fj2m9 if this is your first time opening a
Crossplane pull request. Find us in https://slack.crossplane.io/messages/dev if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open Provider InfluxDB Cloud issue. If yours
does, you can uncomment the below line to indicate which issue your PR fixes,
for example "Fixes #500":

-->
Fixes #7
It looks like we have an issue while detecting/handling not-found errors for buckets. This PR fixes the issue in a minimalist manner.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->
Tested with the following example manifest with a trial InfluxDB Cloud 2 account. Also tested the fix with an InfluxDB organization.
```yaml
apiVersion: influxdb.crossplane.io/v1alpha1
kind: Bucket
metadata:
  name: example-bucket2-alper
spec:
  forProvider:
    description: test-description
    orgID: 4133ee0939674b36
    retentionRules:
    - everySeconds: 3600
      type: expire
  providerConfigRef:
    name: default
```

```
❯ k get bucket
NAME                    READY   SYNCED   EXTERNAL-NAME           AGE
example-bucket2-alper   True    True     example-bucket2-alper   43m
```

[contribution process]: https://git.io/fj2m9
