### PR TITLE
address issue of 0-length RetentionRule

### DIFF
--- a/apis/v1alpha1/bucket_types.go
+++ b/apis/v1alpha1/bucket_types.go
@@ -46,7 +46,8 @@ type BucketParameters struct {
 	RP *string `json:"rp,omitempty"`
 
 	// Rules to expire or retain data. No rules means data never expires.
-	RetentionRules []RetentionRule `json:"retentionRules"`
+	// +optional
+	RetentionRules []RetentionRule `json:"retentionRules,omitempty"`
 
 	// +kubebuilder:validation:Enum=implicit;explicit
 	SchemaType string `json:"schemaType,omitempty"`

--- a/internal/controller/bucket/controller_test.go
+++ b/internal/controller/bucket/controller_test.go
@@ -112,6 +112,56 @@ func TestObserve(t *testing.T) {
 				},
 			},
 		},
+		"ExpireNoUpdateNeeded": {
+			args: args{
+				mg: &v1alpha1.Bucket{
+					Spec: v1alpha1.BucketSpec{
+						ForProvider: v1alpha1.BucketParameters{
+							Description:    pointer.String("bucket"),
+							RetentionRules: []v1alpha1.RetentionRule{{Type: "expire", EverySeconds: 0}},
+						},
+					},
+				},
+				api: &clients.MockBucketsAPI{
+					FindBucketByNameFn: func(_ context.Context, _ string) (*domain.Bucket, error) {
+						return &domain.Bucket{
+							Description: pointer.String("bucket"),
+						}, nil
+					},
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: true,
+				},
+			},
+		},
+		"ExpireUpdateNeeded": {
+			args: args{
+				mg: &v1alpha1.Bucket{
+					Spec: v1alpha1.BucketSpec{
+						ForProvider: v1alpha1.BucketParameters{
+							Description:    pointer.String("bucket"),
+							RetentionRules: []v1alpha1.RetentionRule{{Type: "expire", EverySeconds: 3600}},
+						},
+					},
+				},
+				api: &clients.MockBucketsAPI{
+					FindBucketByNameFn: func(_ context.Context, _ string) (*domain.Bucket, error) {
+						return &domain.Bucket{
+							Description: pointer.String("bucket"),
+						}, nil
+					},
+				},
+			},
+			want: want{
+				obs: managed.ExternalObservation{
+					ResourceExists:   true,
+					ResourceUpToDate: false,
+				},
+			},
+		},
 	}
 
 	for name, tc := range cases {

--- a/internal/controller/bucket/conversions_test.go
+++ b/internal/controller/bucket/conversions_test.go
@@ -1,0 +1,259 @@
+/*
+Copyright 2021 The Crossplane Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package bucket
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/influxdata/influxdb-client-go/v2/domain"
+	"k8s.io/utils/pointer"
+
+	"github.com/crossplane-contrib/provider-influxdb/apis/v1alpha1"
+)
+
+func TestLateInitialize(t *testing.T) {
+	sType := domain.SchemaTypeExplicit
+	type args struct {
+		params *v1alpha1.BucketParameters
+		obs    *domain.Bucket
+	}
+	type want struct {
+		params *v1alpha1.BucketParameters
+		res    bool
+	}
+	cases := map[string]struct {
+		args args
+		want want
+	}{
+		"UpToDate": {
+			args: args{
+				params: &v1alpha1.BucketParameters{
+					Description: pointer.String("name"),
+				},
+				obs: &domain.Bucket{
+					Description: pointer.String("name"),
+				},
+			},
+			want: want{
+				params: &v1alpha1.BucketParameters{
+					Description: pointer.String("name"),
+				},
+				res: false,
+			},
+		},
+		"LateInitDescription": {
+			args: args{
+				params: &v1alpha1.BucketParameters{},
+				obs: &domain.Bucket{
+					Description: pointer.String("LIname"),
+				},
+			},
+			want: want{
+				params: &v1alpha1.BucketParameters{
+					Description: pointer.String("LIname"),
+				},
+				res: true,
+			},
+		},
+		"LateInitSchemaType": {
+			args: args{
+				params: &v1alpha1.BucketParameters{},
+				obs: &domain.Bucket{
+					Description: pointer.String("name"),
+					SchemaType:  &sType,
+				},
+			},
+			want: want{
+				params: &v1alpha1.BucketParameters{
+					Description: pointer.String("name"),
+					SchemaType:  "explicit",
+				},
+				res: true,
+			},
+		},
+		"LateInitRetentionRules": {
+			args: args{
+				params: &v1alpha1.BucketParameters{
+					Description: pointer.String("name"),
+				},
+				obs: &domain.Bucket{
+					Description:    pointer.String("LIname"),
+					RetentionRules: []domain.RetentionRule{{Type: "expire"}},
+				},
+			},
+			want: want{
+				params: &v1alpha1.BucketParameters{
+					Description:    pointer.String("name"),
+					RetentionRules: []v1alpha1.RetentionRule{{Type: "expire"}},
+				},
+				res: true,
+			},
+		},
+		"LateInitIgnoreRetentionRules": {
+			args: args{
+				params: &v1alpha1.BucketParameters{
+					Description:    pointer.String("name"),
+					RetentionRules: []v1alpha1.RetentionRule{{Type: "expire", EverySeconds: 3600}},
+				},
+				obs: &domain.Bucket{
+					Description:    pointer.String("LIname"),
+					RetentionRules: []domain.RetentionRule{{Type: "expire"}},
+				},
+			},
+			want: want{
+				params: &v1alpha1.BucketParameters{
+					Description:    pointer.String("name"),
+					RetentionRules: []v1alpha1.RetentionRule{{Type: "expire", EverySeconds: 3600}},
+				},
+				res: false,
+			},
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := LateInitialize(tc.args.params, tc.args.obs)
+
+			if diff := cmp.Diff(tc.want.res, res); diff != "" {
+				t.Errorf("Observe(...): -want, +got:\n%s", diff)
+			}
+			if diff := cmp.Diff(tc.want.params, tc.args.params); diff != "" {
+				t.Errorf("Observe(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}
+func TestIsUpToDate(t *testing.T) {
+	type args struct {
+		params v1alpha1.BucketParameters
+		obs    *domain.Bucket
+	}
+	cases := map[string]struct {
+		args args
+		want bool
+	}{
+		"UpToDate": {
+			args: args{
+				params: v1alpha1.BucketParameters{
+					Description: pointer.String("name"),
+				},
+				obs: &domain.Bucket{
+					Description: pointer.String("name"),
+				},
+			},
+			want: true,
+		},
+		"DescriptionDifferent": {
+			args: args{
+				params: v1alpha1.BucketParameters{
+					Description: pointer.String("name"),
+				},
+				obs: &domain.Bucket{
+					Description: pointer.String("differentName"),
+				},
+			},
+			want: false,
+		},
+		"DefaultExpire": {
+			args: args{
+				params: v1alpha1.BucketParameters{
+					Description: pointer.String("name"),
+				},
+				obs: &domain.Bucket{
+					Description:    pointer.String("name"),
+					RetentionRules: []domain.RetentionRule{{Type: "expire"}},
+				},
+			},
+			want: true,
+		},
+		"ParamSetToUnexpire": {
+			args: args{
+				params: v1alpha1.BucketParameters{
+					Description:    pointer.String("name"),
+					RetentionRules: []v1alpha1.RetentionRule{{Type: "expire"}},
+				},
+				obs: &domain.Bucket{
+					Description: pointer.String("name"),
+				},
+			},
+			want: true,
+		},
+		"ParamNonDefault": {
+			args: args{
+				params: v1alpha1.BucketParameters{
+					Description:    pointer.String("name"),
+					RetentionRules: []v1alpha1.RetentionRule{{Type: "expire", EverySeconds: 3600}},
+				},
+				obs: &domain.Bucket{
+					Description: pointer.String("name"),
+				},
+			},
+			want: false,
+		},
+		"ShardGroupMatch": {
+			args: args{
+				params: v1alpha1.BucketParameters{
+					Description:    pointer.String("name"),
+					RetentionRules: []v1alpha1.RetentionRule{{Type: "expire", ShardGroupDurationSeconds: pointer.Int64(3600)}},
+				},
+				obs: &domain.Bucket{
+					Description:    pointer.String("name"),
+					RetentionRules: []domain.RetentionRule{{Type: "expire", ShardGroupDurationSeconds: pointer.Int64(3600)}},
+				},
+			},
+			want: true,
+		},
+		"ShardGroupUnequal": {
+			args: args{
+				params: v1alpha1.BucketParameters{
+					Description:    pointer.String("name"),
+					RetentionRules: []v1alpha1.RetentionRule{{Type: "expire", ShardGroupDurationSeconds: pointer.Int64(3600)}},
+				},
+				obs: &domain.Bucket{
+					Description:    pointer.String("name"),
+					RetentionRules: []domain.RetentionRule{{Type: "expire", ShardGroupDurationSeconds: pointer.Int64(7200)}},
+				},
+			},
+			want: false,
+		},
+		"RuleLengthCheck": {
+			args: args{
+				params: v1alpha1.BucketParameters{
+					Description:    pointer.String("name"),
+					RetentionRules: []v1alpha1.RetentionRule{{Type: "expire"}},
+				},
+				obs: &domain.Bucket{
+					Description: pointer.String("name"),
+					RetentionRules: []domain.RetentionRule{
+						{Type: "expire"},
+						{Type: "expire", EverySeconds: 3600},
+					},
+				},
+			},
+			want: false,
+		},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			res := IsUpToDate(tc.args.params, tc.args.obs)
+
+			if diff := cmp.Diff(tc.want, res); diff != "" {
+				t.Errorf("Observe(...): -want, +got:\n%s", diff)
+			}
+		})
+	}
+}

--- a/package/crds/influxdb.crossplane.io_buckets.yaml
+++ b/package/crds/influxdb.crossplane.io_buckets.yaml
@@ -125,8 +125,6 @@ spec:
                     - implicit
                     - explicit
                     type: string
-                required:
-                - retentionRules
                 type: object
               providerConfigRef:
                 default:


### PR DESCRIPTION
Signed-off-by: Steven Borrelli <steve@borrelli.org>



### Description of your changes

Fixes #10 


I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make reviewable test` to ensure this PR is ready for review.

### How has this code been tested

- Created bucket with the following yaml and validated in Influxdb Azure console:

```
apiVersion: influxdb.crossplane.io/v1alpha1
kind: Bucket
metadata:
  name: example-bucket-borrelli-issue-26
spec:
  forProvider:
    description: borrelli-test-issue-10
    orgID: <redacted>
    retentionRules:
    - everySeconds: 0
      type: expire
  providerConfigRef:
    name: default
```

- Deleted bucket and validated in the Influxdb Azure Console

- Created a bucket with a 1 hour retention and confirmed in InfluxDB azure console:

```yaml
apiVersion: influxdb.crossplane.io/v1alpha1
kind: Bucket
metadata:
  name: example-bucket-borrelli-issue-26
spec:
  forProvider:
    description: borrelli-test-issue-26
    orgID: <redacted>
    retentionRules:
    - everySeconds: 3600
      type: expire
  providerConfigRef:
    name: default
```

- Changed `retentionRules` to `everySeconds` to 0 and confirmed in the InfluxDB Azure Console.
- Deleted Bucket and confirmed deletion. Reviewed Controller logs for any Panic. 

